### PR TITLE
Resync with batch normalization and do not use avgpool of cudnn

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ a result like this:
 ```
 RESULTS (top-5):
 ----------------
-score = 0.851581: n02510455 giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca (170)
-score = 0.013321: n02500267 indri, indris, Indri indri, Indri brevicaudatus (76)
-score = 0.003967: n02509815 lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens (8)
-score = 0.001362: n13044778 earthstar (879)
-score = 0.001302: n07760859 custard apple (326)
+score = 0.847576: n02510455 giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca (170)
+score = 0.020494: n02500267 indri, indris, Indri indri, Indri brevicaudatus (76)
+score = 0.003694: n02509815 lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens (8)
+score = 0.001323: n13044778 earthstar (879)
+score = 0.001301: n07760859 custard apple (326)
 ```

--- a/example.lua
+++ b/example.lua
@@ -13,13 +13,13 @@ local input_dim = 299
 
 local load_image = function(path)
   local img   = image.load(path, 3)
-  local c,w,h = img:size(1), img:size(3), img:size(2)
+  local w, h  = img:size(3), img:size(2)
   local min   = math.min(w, h)
   img         = image.crop(img, 'c', min, min)
   img         = image.scale(img, input_dim)
   -- normalize image
   img:mul(255):add(-input_sub):mul(input_scale)
-  -- note that due to batch normalization, we are obliged to use unitary batches
+  -- due to batch normalization we must use minibatches
   return img:float():view(1, img:size(1), img:size(2), img:size(3))
 end
 
@@ -33,6 +33,7 @@ local args = pl.lapp [[
 if args.b == "cunn" then
   require "cunn"
 elseif args.b == "cudnn" then
+  require "cunn"
   require "cudnn"
 end
 


### PR DESCRIPTION
SpatialBatchNomalization changed fields in https://github.com/torch/nn/pull/550

Regarding SpatialAveragePooling, switching to nn/cunn backend as `cudnn.torch`
version [does not support](https://github.com/soumith/cudnn.torch/blob/4fdde0a10e3240959a5924e2f0d0be495a467b1f/SpatialAveragePooling.lua#L25) excluded counting
